### PR TITLE
chore: bump SPARQL Anything to v1.1.0

### DIFF
--- a/map.sh
+++ b/map.sh
@@ -2,7 +2,7 @@
 DATA_DIR="$PWD/data"
 BIN_DIR="$PWD/bin"
 CONFIG_DIR="$PWD/config"
-: "${SPARQL_ANYTHING_VERSION:=v1.0-DEV.15}"
+: "${SPARQL_ANYTHING_VERSION:=v1.1.0}"
 : "${SPARQL_ANYTHING_JAR:=sparql-anything-$SPARQL_ANYTHING_VERSION.jar}"
 : "${OUTPUT_DIR:=$PWD/output}"
 


### PR DESCRIPTION
Bumps SPARQL Anything from `v1.0-DEV.15` (prerelease, March 2025) to `v1.1.0` (stable, December 2025).

## Validation

Smoke-tested locally against the existing `geonames_aa.csv` chunk: jar downloaded cleanly, `admin-codes.rq` and `places.rq` both ran without errors, output IRIs / typed literals / parent-admin lookups / alternate-name splitting all match the previous version’s output shape.
