### PR TITLE
fix: correct mislabelled rdfs: prefix bound to RDF namespace

### DIFF
--- a/config/admin-codes.rq
+++ b/config/admin-codes.rq
@@ -4,7 +4,6 @@ PREFIX gn: <https://www.geonames.org/ontology#>
 PREFIX xyz: <http://sparql.xyz/facade-x/data/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX wgs84_pos: <http://www.w3.org/2003/01/geo/wgs84_pos#>
-PREFIX rdfs: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 CONSTRUCT {
     ?adm1Uri xyz:admin1Code ?adm1 .

--- a/config/places.rq
+++ b/config/places.rq
@@ -4,7 +4,7 @@ PREFIX gn: <https://www.geonames.org/ontology#>
 PREFIX xyz: <http://sparql.xyz/facade-x/data/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX wgs84_pos: <http://www.w3.org/2003/01/geo/wgs84_pos#>
-PREFIX rdfs: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 CONSTRUCT {
     ?uri


### PR DESCRIPTION
Fixes a mislabelled prefix in both CONSTRUCT queries. The label `rdfs:` was declared against the RDF namespace (`http://www.w3.org/1999/02/22-rdf-syntax-ns#`), which is the RDF namespace, not RDFS.

- `places.rq`: rename `rdfs:` → `rdf:`. The CONSTRUCT uses the `a` keyword for `rdf:type`, so output IRIs are unchanged; only the serialised prefix label in the Turtle output changes (`rdfs:type` → `rdf:type` / `a`).
- `admin-codes.rq`: drop the line – the prefix was declared but never referenced.

## Consumer impact

None at the graph level. The expanded IRI in every triple stays the same, so SPARQL queries, RDF parsers, SHACL validators, and federation are all unaffected. The artefact diffs visibly at the Turtle prefix declaration and every `rdfs:type` line, but `riot --output=nt` round-trips to identical N-Triples before and after.

The fix also frees the `rdfs:` label for any future actual RDFS use, preventing a latent footgun where `rdfs:label` would otherwise have resolved to `<rdf-syntax-ns#label>`.
