### PR TITLE
chore: bump SPARQL Anything to v1.1.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:21-jre
 LABEL org.opencontainers.image.source="https://github.com/netwerk-digitaal-erfgoed/geonames-rdf"
-ENV SPARQL_ANYTHING_VERSION=v1.0-DEV.15
+ENV SPARQL_ANYTHING_VERSION=v1.1.0
 ENV SPARQL_ANYTHING_JAR="sparql-anything-$SPARQL_ANYTHING_VERSION.jar"
 ENV OUTPUT_DIR=/output
 WORKDIR /app


### PR DESCRIPTION
Follow-up to #22. The `Dockerfile` pins `SPARQL_ANYTHING_VERSION` independently of `map.sh` and was missed in the previous bump, so the published image at `ghcr.io/netwerk-digitaal-erfgoed/geonames-rdf` would still pull `v1.0-DEV.15` until this lands.

No effect on the weekly harvest (which uses `actions/setup-java` directly, not the image) – this only affects external users who follow the README’s `docker run` instructions.
