### PR TITLE
fix: set csv.quote-char to handle literal quotes in GeoNames data

### DIFF
--- a/config/admin-codes.rq
+++ b/config/admin-codes.rq
@@ -15,7 +15,6 @@ WHERE {
             fx:properties fx:location "data/admin1-codes.csv" ;
                 fx:csv.delimiter "\t" ;
                 fx:csv.headers true ;
-                fx:csv.quote-char "\u0001" ;
             .
             [
                 xyz:admin1code ?adm1 ;
@@ -29,7 +28,6 @@ WHERE {
             fx:properties fx:location "data/admin2-codes.csv" ;
                 fx:csv.delimiter "\t" ;
                 fx:csv.headers true ;
-                fx:csv.quote-char "\u0001" ;
             .
             [
                 xyz:admin2code ?adm2 ;

--- a/config/admin-codes.rq
+++ b/config/admin-codes.rq
@@ -15,6 +15,7 @@ WHERE {
             fx:properties fx:location "data/admin1-codes.csv" ;
                 fx:csv.delimiter "\t" ;
                 fx:csv.headers true ;
+                fx:csv.quote-char "\u0001" ;
             .
             [
                 xyz:admin1code ?adm1 ;
@@ -28,6 +29,7 @@ WHERE {
             fx:properties fx:location "data/admin2-codes.csv" ;
                 fx:csv.delimiter "\t" ;
                 fx:csv.headers true ;
+                fx:csv.quote-char "\u0001" ;
             .
             [
                 xyz:admin2code ?adm2 ;

--- a/config/places.rq
+++ b/config/places.rq
@@ -29,7 +29,7 @@ WHERE {
             fx:null-string "" ; # Skip empty alternate names.
             fx:csv.delimiter "\t" ;
             fx:csv.headers true ;
-            fx:csv.quote-char "\u0001" ; # GeoNames TSV is unquoted but contains literal '"' in some names; pick a control char that never appears in the data so Apache Commons CSV treats '"' as plain data.
+            fx:csv.quote-char "\u0001" ; # GeoNames TSV is unquoted but contains literal '"' in some names (e.g. '"Kostas Tsianos" Theatre'); pick a control char that never appears in the data so Apache Commons CSV treats '"' as plain data.
         .
 
         ?s xyz:geonameid ?id ;

--- a/config/places.rq
+++ b/config/places.rq
@@ -29,6 +29,7 @@ WHERE {
             fx:null-string "" ; # Skip empty alternate names.
             fx:csv.delimiter "\t" ;
             fx:csv.headers true ;
+            fx:csv.quote-char "\u0001" ; # GeoNames TSV is unquoted but contains literal '"' in some names; pick a control char that never appears in the data so Apache Commons CSV treats '"' as plain data.
         .
 
         ?s xyz:geonameid ?id ;


### PR DESCRIPTION
Apache Commons CSV (the parser SPARQL Anything uses) defaults its quote character to `"`. GeoNames TSV is unquoted, but place names can contain **literal** ASCII double quotes. Today’s `allCountries.txt` dump has 14 rows where the name field starts with `"` — e.g.

```
13526837	"Kostas Tsianos" Theatre	...
```

(modification date 2025-09-25). When the parser sees the leading `"` it interprets it as opening a quoted field, fails to find a clean close, and aborts with `(line N) invalid char between encapsulated token and delimiter`.

## Fix

Set `fx:csv.quote-char` to U+0001 (SOH) — a control character that cannot occur in real-world GeoNames data — so Commons CSV treats `"` as plain data.

Only `places.rq` is changed. `admin-codes.rq` reads the admin code dumps (`admin1CodesASCII.txt`, `admin2Codes.txt`), which are short identifier-style files with no literal quotes.

## Reproduced in CI

Triggered a manual workflow_dispatch run of `harvest.yml` against today’s GeoNames data and observed the crash at line 311,065 of `geonames_ae.csv` (= `"Kostas Tsianos" Theatre`): https://github.com/netwerk-digitaal-erfgoed/geonames-rdf/actions/runs/26566957306. The 14 quote-starting rows are spread across 6 chunks (`ad`, `ae`, `ah`, `aj`, `am`, `an`), each of which crashes at its first such row. `map.sh` has no `set -e`, so the script continues past each crash and exits 0; the final `cat *.csv.ttl > geonames.ttl` concatenates the surviving chunks.

The publish pipeline being scheduled-disabled since 2025-11-30 means no recent partial dump has been shipped to DO Spaces — but until that workflow was disabled, this bug had been silently corrupting weekly artefacts since at least the Kostas Tsianos record was added on 2025-09-25.

## Notes on the chosen workaround

I tried `fx:csv.format "TDF"` first, on the assumption that Apache Commons CSV’s TDF preset would disable quoting. It does not — TDF only sets `\t` as the delimiter and `ignoreSurroundingSpaces`; the quote character stays `"`. So TDF still crashes (just at a slightly different line because of whitespace stripping).

There is no clean "disable quoting" knob in SPARQL Anything today — `withQuote(null)` in Apache Commons CSV is not surfaced through any `fx:csv.*` option. Filed as an upstream feature request: [SPARQL-Anything/sparql.anything#625](https://github.com/SPARQL-Anything/sparql.anything/issues/625). Until that lands, the sentinel-character workaround is the only stable lever.
