### PR TITLE
build: enable Dependabot for github-actions and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering the two ecosystems present in this repo:

- **`github-actions`** – the actions used in `harvest.yml` and `publish.yml` (`actions/checkout`, `actions/setup-java`, `actions/upload-artifact`, `docker/*`, `BetaHuhn/do-spaces-action`). Grouped into a single weekly PR to keep noise down.
- **`docker`** – the `eclipse-temurin:21-jre` base image in `Dockerfile`. Weekly.

The SPARQL Anything jar is downloaded by `map.sh` at build/run time rather than declared as a dependency, so it stays managed manually – the recent bump to v1.1.0 is the pattern we’ll keep for that one.

## Side benefit: keep `harvest.yml` from auto-disabling

GitHub auto-disables scheduled workflows after 60 days of repo inactivity (which is what happened to `harvest.yml` between 2025-11-30 and today – it’s currently in state `disabled_inactivity`). Routine Dependabot merges land commits on `main` and reset that timer. The Docker ecosystem alone (Temurin patches monthly) should be enough to keep us well inside the window, provided someone is merging the PRs.

If we want belt-and-braces, a separate change could add a self-touching step to the harvest itself – but Dependabot is the smaller and more valuable lever.

After this lands, the harvest workflow still needs an explicit one-time re-enable: `gh workflow enable harvest.yml --repo netwerk-digitaal-erfgoed/geonames-rdf`.
