### PR TITLE
build: don't auto-bump eclipse-temurin major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # SPARQL Anything v1.1.0 only tests on Java 21 upstream; don't auto-bump
+      # the JRE major until that changes. Patch updates within 21-jre still flow.
+      - dependency-name: "eclipse-temurin"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Pins Dependabot to patch updates only for `eclipse-temurin` until SPARQL Anything declares Java 25 support. v1.1.0 compiles targeting Java 17 and tests on Java 21 (`build_on_maven_java21.yml` upstream); no Java 25 CI job exists yet. Patch updates within 21-jre still flow normally.

Closes the auto-bump path of #27 (the open Temurin 21→25 PR) – it should be closed once this lands.