### PR TITLE
feat: emit continents that have no country code

### DIFF
--- a/config/places.rq
+++ b/config/places.rq
@@ -34,7 +34,6 @@ WHERE {
 
         ?s xyz:geonameid ?id ;
             xyz:name ?name ;
-            xyz:country%20code ?countryCode ;
             xyz:feature%20class ?featureClassString ;
             xyz:feature%20code ?featureCodeString ;
             xyz:latitude ?latitude ;
@@ -42,6 +41,13 @@ WHERE {
             xyz:adm1 ?adm1 ;
             xyz:adm2 ?adm2 ; # Not all places have a parentAdm2, but we use a special 'NONE' value so we can join non-OPTIONALly.
         .
+
+        # Continents have no country code, which fx:null-string drops, so the required
+        # country-code pattern omitted them. Bind it OPTIONALly and keep country-less features
+        # only when they are continents (feature code L.CONT); other country-less features
+        # (oceans, undersea features, the planet) stay out of scope.
+        OPTIONAL { ?s xyz:country%20code ?countryCode }
+        FILTER(BOUND(?countryCode) || (?featureClassString = "L" && ?featureCodeString = "CONT"))
 
         OPTIONAL {
             ?s xyz:population ?population .


### PR DESCRIPTION
## Problem

Continents – e.g. [`6255146` Africa](https://sws.geonames.org/6255146/) (`featureCode=L.CONT`), Europe, etc. – were silently dropped from the generated `geonames.ttl` and could not be resolved or found downstream (the Network of Terms lookup returned `NotFoundError` for Africa, while features that carry a country code resolve fine).

## Cause

In `config/places.rq`, `gn:countryCode` was bound from a **required** triple pattern combined with `fx:null-string ""`. A continent’s empty `country code` cell yields no binding for `?countryCode`, so the entire `CONSTRUCT` row produced no output and the feature was omitted.

## Fix

Bind the country code via `OPTIONAL`, and keep country-less rows **only when they are continents** (`L.CONT`):

```sparql
OPTIONAL { ?s xyz:country%20code ?countryCode }
FILTER(BOUND(?countryCode) || (?featureClassString = "L" && ?featureCodeString = "CONT"))
```

`gn:countryCode` is simply absent for continents, which matches the upstream GeoNames data.

### Why scope to `L.CONT` and not all country-less features

An empty country code applies to **6,994** GeoNames features, the vast majority of which we do **not** want in this dataset:

| Class | Count | Examples |
| --- | --- | --- |
| U (undersea) | 6,123 | seamounts, canyons, ridges |
| H (water) | 462 | oceans, seas, gulfs, but also streams/wells (data gaps) |
| T (terrain) | 160 | cross-border ranges, atolls |
| L (area/region) | 137 | **continents (7)**, the planet, regions, oil/gas fields |
| S (spot/building) | 98 | universities, stations, lighthouses – plainly **data-entry gaps** |
| A / R / V | 14 | historical entities, Eurotunnel |

Most of these have no country code only because of upstream data gaps (e.g. a university with a blank cell), not because they are genuinely supranational. Filtering to `L.CONT` at harvest time (inside the SPARQL Anything `SERVICE` block, baked into the static `geonames.ttl`) adds exactly the **7 continents** and keeps the rest of that mess out of the data.

## Verification

Drove this red→green against a fixture of real rows run through the SPARQL Anything jar:

- Africa (`L.CONT`, empty country code) → emitted, with no `gn:countryCode`.
- Earth (`L.AREA`), Indian Ocean (`H.OCN`), and an `S.*` row (`15904`, empty country code) → dropped.
- Amsterdam (`P.PPLC`, `NL`) → unaffected, still carries `gn:countryCode "NL"`.

The extra `OPTIONAL` operates on the already-bound `?s` within the same Facade-X row container (a per-row left join, not a cross-graph join), so it has no measurable performance impact – confirmed head-to-head on a 200k-row chunk (≈46s either way, within `ondisk` I/O noise).

## Downstream follow-up

Continents now arrive without `gn:countryCode`. The Network of Terms queries also require it, so they need handling for the missing code – tracked in netwerk-digitaal-erfgoed/network-of-terms#1867 (lookup as priority fix; search as a scoped follow-up).

Fix #30
