### PR TITLE
fix: fail the build on dropped chunks instead of publishing incomplete data

### DIFF
--- a/map.sh
+++ b/map.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Abort on the first error so a crashing chunk fails the build loudly instead of
+# silently dropping ~1M rows from the output while the job stays green.
+set -eu
+
 DATA_DIR="$PWD/data"
 BIN_DIR="$PWD/bin"
 CONFIG_DIR="$PWD/config"
@@ -16,8 +20,14 @@ fi
 # Map admin codes.
 java -jar $BIN_DIR/$SPARQL_ANYTHING_JAR -q $CONFIG_DIR/admin-codes.rq > $DATA_DIR/admin-codes.ttl
 
+# Remove stale chunk outputs from a previous run, so the cat below can only pick up .ttl files
+# this run produced (relevant when map.sh is run standalone without download.sh).
+rm -f $DATA_DIR/geonames_*.csv.ttl
+
 # Iterate over chunks and run them through SPARQL Anything individually to prevent OOMs.
-trap "exit 1" INT
+# set -e aborts the run if a chunk crashes (SPARQL Anything v1.1.0+ deletes its output on a
+# crash, so the cat below would otherwise silently omit it); the "Processing" line above
+# identifies the failing chunk.
 for f in $DATA_DIR/geonames_*.csv; do
     echo "Processing $f"
     java -jar $BIN_DIR/$SPARQL_ANYTHING_JAR --query "$(sed "s|{SOURCE}|$f|" $CONFIG_DIR/places.rq)" --load $DATA_DIR/admin-codes.ttl --output $f.ttl


### PR DESCRIPTION
## Why

The conversion pipeline could silently drop data on an otherwise-green build. `map.sh` ran each chunk through SPARQL Anything without checking the exit code (no `set -e`; the only `trap` caught SIGINT, not a failed `java` process), then `cat`-ed whatever `*.csv.ttl` files happened to exist. With SPARQL Anything v1.1.0+ deleting its output on a crash, a failed chunk leaves no `.ttl`, so the concatenation silently omits ~1M rows while the job stays green and `harvest.yml` uploads the incomplete dataset to production.

This is the class of bug behind the recent CSV-quote incident: a crashing chunk leading to silent data loss with no signal.

## What

- Replace the SIGINT-only `trap "exit 1" INT` with `set -eu`, so a crashing chunk aborts the run. SPARQL Anything v1.1.0+ deletes its output on crash; the old script ignored the exit code, so the chunk was silently omitted from the concatenation. The `Processing $f` log line identifies which chunk failed.
- Clear stale chunk outputs (`rm -f data/geonames_*.csv.ttl`) before the loop, so a standalone `map.sh` run cannot pick up `.ttl` files left over from a previous run.

`set -eu` does the real work — a chunk failure is a non-zero exit, which now aborts before the upload step. No separate completeness check is needed: there is no path where a chunk fails without a non-zero exit. (An aggregate gate that would add signal — a tight relative-regression count vs. the previous run — belongs in the LDE pipeline; see [ldelements/lde#18](https://github.com/ldelements/lde/issues/18) and [#81](https://github.com/ldelements/lde/issues/81).)

All of this lives in `map.sh`: a non-zero exit there already blocks the downstream S3 upload in `harvest.yml` (its upload steps have no `if: always()`), so no workflow change is needed.

## Verification

- `sh -n map.sh` passes.
- A non-zero exit from any chunk aborts the run under `set -e` (verified in isolation); the preceding `Processing $f` line names the failing chunk.
