### PR TITLE
feat: output N-Triples instead of Turtle

### DIFF
--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -18,11 +18,11 @@ jobs:
       - run: ./map.sh
       - uses: actions/upload-artifact@v7
         with:
-          name: geonames-ttl
-          path: output/geonames.ttl
+          name: geonames-nt
+          path: output/geonames.nt
       - run: |
           cd output
-          zip -r geonames.zip geonames.ttl
+          zip -r geonames.zip geonames.nt
       - uses: BetaHuhn/do-spaces-action@v2
         with:
           access_key: ${{ secrets.S3_ACCESS_KEY}}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains shell scripts that download [GeoNames data dumps](https://download.geonames.org/export/dump/)
 and convert them to RDF using [SPARQL Anything](https://github.com/SPARQL-Anything/sparql.anything),
-resulting in a `geonames.ttl` file that you can load into a SPARQL server.
+resulting in a `geonames.nt` file that you can load into a SPARQL server.
 
 You can download a periodically updated RDF file from http://geonames.ams3.digitaloceanspaces.com/geonames.zip (420 MB).
 
@@ -36,5 +36,5 @@ This will download SPARQL Anything if not already available.
 
 ## Output
 
-After running the transform process, you’ll find a `output/geonames.ttl` file 
+After running the transform process, you’ll find a `output/geonames.nt` file 
 that you can load into a SPARQL server. 

--- a/map.sh
+++ b/map.sh
@@ -20,9 +20,9 @@ fi
 # Map admin codes.
 java -jar $BIN_DIR/$SPARQL_ANYTHING_JAR -q $CONFIG_DIR/admin-codes.rq > $DATA_DIR/admin-codes.ttl
 
-# Remove stale chunk outputs from a previous run, so the cat below can only pick up .ttl files
+# Remove stale chunk outputs from a previous run, so the cat below can only pick up .nt files
 # this run produced (relevant when map.sh is run standalone without download.sh).
-rm -f $DATA_DIR/geonames_*.csv.ttl
+rm -f $DATA_DIR/geonames_*.csv.nt
 
 # Iterate over chunks and run them through SPARQL Anything individually to prevent OOMs.
 # set -e aborts the run if a chunk crashes (SPARQL Anything v1.1.0+ deletes its output on a
@@ -30,7 +30,9 @@ rm -f $DATA_DIR/geonames_*.csv.ttl
 # identifies the failing chunk.
 for f in $DATA_DIR/geonames_*.csv; do
     echo "Processing $f"
-    java -jar $BIN_DIR/$SPARQL_ANYTHING_JAR --query "$(sed "s|{SOURCE}|$f|" $CONFIG_DIR/places.rq)" --load $DATA_DIR/admin-codes.ttl --output $f.ttl
+    java -jar $BIN_DIR/$SPARQL_ANYTHING_JAR --query "$(sed "s|{SOURCE}|$f|" $CONFIG_DIR/places.rq)" --load $DATA_DIR/admin-codes.ttl --format NT --output $f.nt
 done
 
-cat $DATA_DIR/*.csv.ttl > $OUTPUT_DIR/geonames.ttl
+# Concatenate the per-chunk N-Triples files. Unlike Turtle, N-Triples has no prefixes or
+# document structure: every line is a self-contained triple, so plain cat is always valid.
+cat $DATA_DIR/*.csv.nt > $OUTPUT_DIR/geonames.nt

--- a/server.sh
+++ b/server.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 cd fuseki
-docker-compose run --rm --name gnserver --service-ports fuseki --file=/fuseki/databases/geonames.ttl /geonames
+docker-compose run --rm --name gnserver --service-ports fuseki --file=/fuseki/databases/geonames.nt /geonames
 cd ..


### PR DESCRIPTION
## What

Emit **N-Triples** (`geonames.nt`) instead of Turtle (`geonames.ttl`).

- `map.sh` passes `--format NT` and writes `geonames.nt` per chunk, then concatenates the chunks into `output/geonames.nt`.
- `harvest.yml` publishes `geonames.nt` inside `geonames.zip`.
- `server.sh` (local Fuseki harness) loads `geonames.nt`.
- README describes the `geonames.nt` output.

The internal intermediate `admin-codes.ttl` stays Turtle – it is `--load`ed back into the query, not published.

## Why

`map.sh` builds the final file by `cat`-ing the per-chunk outputs. Catting Turtle only works because each chunk is a complete document and Turtle tolerates repeated `@prefix` blocks – valid but fragile. N-Triples has no prefixes and no document structure (every line is a self-contained `S P O .`), so concatenation is trivially, unconditionally correct. N-Triples is also faster to serialise and cleaner to stream-parse later. The artifact is zipped, so the larger uncompressed size mostly disappears on the wire.

`--format NT` is passed explicitly rather than relying on the `.nt` filename extension: for `CONSTRUCT` queries SPARQL Anything defaults to Turtle, so the serialisation stays correct even if the output filename ever changes.

## Consumer-facing change

The published artifact is still `geonames.zip` at the same stable URL `http://geonames.ams3.digitaloceanspaces.com/geonames.zip`. **The zip name and URL are unchanged, but its contents change from `geonames.ttl` to `geonames.nt`.** Downstream consumers that load the file will receive N-Triples (SPARQL servers ingest N-Triples identically to Turtle).

## Required follow-up (separate repo)

The production loader in `infrastructure/k8s/geonames-sparql/` (`indexer.yaml`, `reindex-job.yaml`) unzips `geonames.zip` and runs `tdb2.xloader … /scratch/geonames.ttl`. It must switch to `geonames.nt` **before** the first harvest publishes a `.nt` zip, or the (re)index will fail to find the file. `harvest.yml` publishes only on schedule (Sunday 03:00 UTC) or manual dispatch, so merging this PR does not publish anything by itself.

## Verification

Ran `download.sh` + `map.sh` locally on an NL + BE subset: produced a valid `geonames.nt` (438,043 triples) and round-tripped it back through Jena (`tdb2`/SPARQL Anything) – line count equals triple count, confirming well-formed N-Triples.
