### PR TITLE
feat: replace on-disk storage with SPARQL Anything row slicing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM eclipse-temurin:21-jre
 LABEL org.opencontainers.image.source="https://github.com/netwerk-digitaal-erfgoed/geonames-rdf"
-ENV SPARQL_ANYTHING_VERSION=v1.1.0
-ENV SPARQL_ANYTHING_JAR="sparql-anything-$SPARQL_ANYTHING_VERSION.jar"
 ENV OUTPUT_DIR=/output
 WORKDIR /app
 RUN mkdir bin
 
 RUN apt-get update && apt-get install zip -y && rm -rf /var/lib/apt/lists/*
-RUN curl -L https://github.com/SPARQL-Anything/sparql.anything/releases/download/$SPARQL_ANYTHING_VERSION/$SPARQL_ANYTHING_JAR -o bin/$SPARQL_ANYTHING_JAR
+# Pre-download the SPARQL Anything jar, using the version pinned in sparql-anything.env
+# (the single source of truth shared with map.sh).
+COPY sparql-anything.env ./
+RUN . ./sparql-anything.env && curl -L https://github.com/SPARQL-Anything/sparql.anything/releases/download/$SPARQL_ANYTHING_VERSION/$SPARQL_ANYTHING_JAR -o bin/$SPARQL_ANYTHING_JAR
 COPY . .
 ENTRYPOINT ["./entrypoint.sh"]

--- a/config/places.rq
+++ b/config/places.rq
@@ -24,12 +24,12 @@ WHERE {
     SERVICE <x-sparql-anything:> {
         fx:properties
             fx:location "{SOURCE}" ;
-            fx:ondisk "/tmp/sparql-anything-geonames" ; # Ondisk storage is slower but required to prevent OOM.
-            fx:ondisk.reuse false ; # Prevents OOM.
+            fx:slice true ; # Stream the chunk in row batches instead of loading it whole; replaces the slow fx:ondisk. Needs SPARQL Anything >= 1.2 (https://github.com/SPARQL-Anything/sparql.anything/issues/624).
+            fx:slice.size "1000" ; # Rows per query execution: bounds input memory while keeping throughput high.
             fx:null-string "" ; # Skip empty alternate names.
             fx:csv.delimiter "\t" ;
             fx:csv.headers true ;
-            fx:csv.quote-char "\u0001" ; # GeoNames TSV is unquoted but contains literal '"' in some names (e.g. '"Kostas Tsianos" Theatre'); pick a control char that never appears in the data so Apache Commons CSV treats '"' as plain data.
+            fx:csv.quote-char "false" ; # GeoNames TSV is unquoted but contains literal '"' in some names (e.g. '"Kostas Tsianos" Theatre'); disable quoting so Apache Commons CSV treats '"' as plain data. Needs SPARQL Anything >= 1.2 (https://github.com/SPARQL-Anything/sparql.anything/issues/625).
         .
 
         ?s xyz:geonameid ?id ;

--- a/map.sh
+++ b/map.sh
@@ -6,8 +6,8 @@ set -eu
 DATA_DIR="$PWD/data"
 BIN_DIR="$PWD/bin"
 CONFIG_DIR="$PWD/config"
-: "${SPARQL_ANYTHING_VERSION:=v1.1.0}"
-: "${SPARQL_ANYTHING_JAR:=sparql-anything-$SPARQL_ANYTHING_VERSION.jar}"
+# SPARQL Anything version/jar are pinned in one place, shared with the Dockerfile.
+. "$PWD/sparql-anything.env"
 : "${OUTPUT_DIR:=$PWD/output}"
 
 mkdir -p $OUTPUT_DIR

--- a/sparql-anything.env
+++ b/sparql-anything.env
@@ -1,0 +1,13 @@
+# Single source of truth for the SPARQL Anything build used by the pipeline.
+# Sourced by map.sh (host + container runtime) and by the Dockerfile (build-time download).
+#
+# Pinned to a v1.2-DEV nightly for the fx:slice.size and fx:csv.quote-char fixes that
+# config/places.rq relies on. Nightly release tags (snapshot-<date>-<time>) differ from
+# the jar filename (a constant), so both are set explicitly.
+# TODO(draft): bump SPARQL_ANYTHING_VERSION to the first nightly on/after 2026-07-11 that
+# includes both fixes; the 20260710 nightly predates the commits. See the PR description.
+#
+# The := defaults let an external environment variable override the pin (e.g. to test
+# another build) without editing this file.
+: "${SPARQL_ANYTHING_VERSION:=snapshot-20260711-000000}"
+: "${SPARQL_ANYTHING_JAR:=sparql-anything-1.2.0-NIGHTLY-SNAPSHOT.jar}"


### PR DESCRIPTION
## What

Move the mapping off SPARQL Anything's on-disk storage and onto the new row-slicing feature, and adopt the proper no-quote option for the unquoted GeoNames TSV.

- `config/places.rq`: replace `fx:ondisk` / `fx:ondisk.reuse` with `fx:slice true` + `fx:slice.size "1000"`, and replace the `fx:csv.quote-char` control-char workaround with `fx:csv.quote-char "false"`. Both require SPARQL Anything >= 1.2.
- New `sparql-anything.env` holds the pinned version as a single source of truth, sourced by both `map.sh` (host + container runtime) and the `Dockerfile` (build-time download) — so a version bump touches one file. Nightly release tags (`snapshot-<date>-<time>`) differ from the constant jar filename (`sparql-anything-1.2.0-NIGHTLY-SNAPSHOT.jar`), so `SPARQL_ANYTHING_VERSION` and `SPARQL_ANYTHING_JAR` are both set there.

We keep the external `split` as the per-chunk memory fence: CONSTRUCT output is still materialised in an in-memory model, so a single JVM over the whole 12M-row dataset would need ~8 GB (filed upstream as SPARQL-Anything/sparql.anything#635). Splitting keeps each JVM bounded.

## Why draft — blocked on the next nightly

No published nightly contains the two fixes yet. The latest, `snapshot-20260710-060233`, was built 06:09 UTC on 2026-07-10, before the fix commits (10:55–11:22 UTC the same day). The pinned tag `snapshot-20260711-000000` is a **placeholder**.

Before this can leave draft / merge:

1. Bump `SPARQL_ANYTHING_VERSION` in `sparql-anything.env` to the first nightly on/after 2026-07-11 that includes SPARQL-Anything/sparql.anything#624 (`fx:slice.size`) and #625 (`fx:csv.quote-char`).
2. Run a real harvest to confirm end-to-end output.

## Verification so far

Verified locally against a from-source build of SPARQL Anything `main` (has both fixes). Running the full `config/places.rq` on a GeoNames-format chunk produces correct output with slicing, covering: literal-quote names (`"Kostas Tsianos" Theatre`), `alternatenames` splitting, both admin-code joins (`parentADM1`/`parentADM2`) against the `--load`ed graph, the continent (`L.CONT`, no country code) filter, and `population = 0` dropping.

## Performance

On a 1M-row chunk → 1,857,143 triples (identical output):

| method | wall | peak RSS |
|---|---|---|
| whole-file + `fx:ondisk` (current) | 71 s | 2690 MB |
| `fx:slice.size 1000`, no ondisk (`-Xmx1g`) | 10 s | 1166 MB |

~7.6× faster at under half the memory.

## Upstream

- SPARQL-Anything/sparql.anything#625 — `fx:csv.quote-char` boolean/no-quote
- SPARQL-Anything/sparql.anything#624 — `fx:slice.size`
- SPARQL-Anything/sparql.anything#635 — stream CONSTRUCT output (would let us drop `split` entirely)
